### PR TITLE
Adding xlim and ylim Parameters 

### DIFF
--- a/R/scatterD3.R
+++ b/R/scatterD3.R
@@ -50,13 +50,30 @@ scatterD3 <- function(x, y, lab = NULL,
                       tooltip_text = NULL,
                       xlab = NULL, ylab = NULL,
                       html_id = NULL,
-                      width = NULL, height = NULL) {
+                      width = NULL, height = NULL,
+                      xlim = NULL, ylim = NULL) {
 
   if (is.null(xlab)) xlab <- deparse(substitute(x))
   if (is.null(ylab)) ylab <- deparse(substitute(y))
   if (is.null(col_lab)) col_lab <- deparse(substitute(col_var))
   if (is.null(symbol_lab)) symbol_lab <- deparse(substitute(symbol_var))
   if (is.null(html_id)) html_id <- paste0("scatterD3-", paste0(sample(LETTERS,8,replace=TRUE),collapse=""))
+
+  if (is.null(xlim)) {
+    xmin <- NULL
+    xmax <- NULL
+  } else {
+    xmin <- xlim[1]
+    xmax <- xlim[2]
+  }
+
+  if (is.null(ylim)) {
+    ymin <- NULL
+    ymax <- NULL
+  } else {
+    ymin <- ylim[1]
+    ymax <- ylim[2]
+  }
 
   # create a list that contains the settings
   settings <- list(
@@ -72,7 +89,11 @@ scatterD3 <- function(x, y, lab = NULL,
     tooltips = tooltips,
     tooltip_text = tooltip_text,
     fixed = fixed,
-    html_id = html_id
+    html_id = html_id,
+    xmin = xmin,
+    xmax = xmax,
+    ymin = ymin,
+    ymax = ymax
   )
 
   data <- data.frame(x=x, y=y)

--- a/inst/htmlwidgets/scatterD3.js
+++ b/inst/htmlwidgets/scatterD3.js
@@ -32,6 +32,10 @@ var scatterD3_store = {};
 	ylab = obj.settings.ylab;
 	col_lab = obj.settings.col_lab;
 	symbol_lab = obj.settings.symbol_lab;
+	xmin = obj.settings.xmin;
+	xmax = obj.settings.xmax;
+	ymin = obj.settings.ymin;
+	ymax = obj.settings.ymax;
 
 	// Store settings in global store in order
 	// for every widget on the page to be able to
@@ -133,15 +137,35 @@ var scatterD3_store = {};
 		.scaleExtent([1, 32])
 		.on("zoom", zoomed);
 
-	    if (fixed) {
-		min_x = min_y = d3.min(data, function(d) { return Math.min(d.x,d.y);} );
-		max_x = max_y = d3.max(data, function(d) { return Math.max(d.x,d.y);} );
-	    } else {
-		min_x = d3.min(data, function(d) { return Math.min(d.x);} );
-		max_x = d3.max(data, function(d) { return Math.max(d.x);} );
-		min_y = d3.min(data, function(d) { return Math.min(d.y);} );
-		max_y = d3.max(data, function(d) { return Math.max(d.y);} );
-	    }
+		if (xmin === null) {
+			min_x = d3.min(data, function(d) { return Math.min(d.x);} );
+		} else {
+			min_x = xmin;
+		} 
+
+		if (xmax === null) {
+			max_x = d3.max(data, function(d) { return Math.max(d.x);} );
+		} else {
+			max_x = xmax;
+		} 
+
+		if (ymin === null) {
+			min_y = d3.min(data, function(d) { return Math.min(d.y);} );
+		} else {
+			min_y = ymin;
+		} 
+
+		if (ymax === null) {
+			max_y = d3.max(data, function(d) { return Math.max(d.y);} );
+		} else {
+			max_y = ymax;
+		} 
+
+		if (fixed) {
+			min_x = min_y = Math.min(min_x, min_y);
+			max_x = max_y = Math.max(max_x, max_y);
+		}
+
 	    gap_x = (max_x - min_x) * 0.2;
 	    gap_y = (max_y - min_y) * 0.2;
 	    x.domain([min_x - gap_x, max_x + gap_x]);

--- a/inst/htmlwidgets/scatterD3.js
+++ b/inst/htmlwidgets/scatterD3.js
@@ -6,7 +6,7 @@ var scatterD3_store = {};
     var data;
     var margin, legend_width, width, height, total_width, total_height;
     var point_size, labels_size, point_opacity;
-    var xlab, ylab, col_lab, symbol_lab, fixed;
+    var xlab, ylab, col_lab, symbol_lab, xmin, xmax, ymin, ymax, fixed;
     var color_legend, symbol_legend, has_legend, has_labels, has_tooltips, has_custom_tooltips;
     var tooltip;
     


### PR DESCRIPTION
This pull request adds the parameters xlim and ylim to the html widget. This would allow users to specify the limits on both the x and y-axes of their plot instead of forcing the dimensions to be dependent on the data.

This is analogous to how the xlim and ylim parameters work in base R plot and ggplots.
